### PR TITLE
fix: missing primary key for radusergroup migration

### DIFF
--- a/src/Database/Migrations/2024-01-21-223112_create_radius_tables.php
+++ b/src/Database/Migrations/2024-01-21-223112_create_radius_tables.php
@@ -145,6 +145,7 @@ class CreateRadiusTables extends Migration
                 'groupname' => ['type' => 'VARCHAR', 'constraint' => 64, 'default' => ''],
                 'priority'  => ['type' => 'INT', 'constraint' => 11, 'unsigned' => true, 'default' => 1],
             ]);
+            $this->forge->addPrimaryKey('id');
             $this->forge->addKey('username');
             $this->forge->createTable($this->tables['radusergroup']);
         }


### PR DESCRIPTION
This pull request includes a significant change to the `src/Database/Migrations/2024-01-21-223112_create_radius_tables.php` file. The most important change is the addition of a primary key to the `radusergroup` table.

Database schema update:

* [`src/Database/Migrations/2024-01-21-223112_create_radius_tables.php`](diffhunk://#diff-3bf7393de87fceaae25f5652cbac4bf14df957cbdd66e44116e9739a1b11bc91R148): Added a primary key to the `radusergroup` table by including the `addPrimaryKey('id')` method in the `up` function.