### PR TITLE
refactor: radusergroup migration fix

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,7 @@ parameters:
 	excludePaths:
 	ignoreErrors:
 	- '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::tableExists\(\)#'
+	- '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::getFieldData\(\)#'
 	universalObjectCratesClasses:
 		- CodeIgniter\Entity
 		- CodeIgniter\Entity\Entity

--- a/src/Database/Migrations/2024-01-21-223112_create_radius_tables.php
+++ b/src/Database/Migrations/2024-01-21-223112_create_radius_tables.php
@@ -145,7 +145,6 @@ class CreateRadiusTables extends Migration
                 'groupname' => ['type' => 'VARCHAR', 'constraint' => 64, 'default' => ''],
                 'priority'  => ['type' => 'INT', 'constraint' => 11, 'unsigned' => true, 'default' => 1],
             ]);
-            $this->forge->addPrimaryKey('id');
             $this->forge->addKey('username');
             $this->forge->createTable($this->tables['radusergroup']);
         }

--- a/src/Database/Migrations/2024-12-02-223112_alter_radusegroup_primary_key.php
+++ b/src/Database/Migrations/2024-12-02-223112_alter_radusegroup_primary_key.php
@@ -28,7 +28,6 @@ class AlterRadusergroupPrimaryKey extends Migration
 
     public function up(): void
     {
-        // Table structure for table 'radusergroup'
         if ($this->db->tableExists($this->tables['radusergroup'])) {
             $fields           = $this->db->getFieldData($this->tables['radusergroup']);
             $primaryKeyExists = false;

--- a/src/Database/Migrations/2024-12-02-223112_alter_radusegroup_primary_key.php
+++ b/src/Database/Migrations/2024-12-02-223112_alter_radusegroup_primary_key.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IctSolutions\CodeIgniterFreeRadius\Database\Migrations;
+
+use CodeIgniter\Database\Forge;
+use CodeIgniter\Database\Migration;
+use IctSolutions\CodeIgniterFreeRadius\Config\FreeRadius;
+
+class AlterRadusergroupPrimaryKey extends Migration
+{
+    private array $tables;
+
+    public function __construct(?Forge $forge = null)
+    {
+        /** @var FreeRadius $freeRadiusConfig */
+        $freeRadiusConfig = config('FreeRadius');
+
+        if ($freeRadiusConfig->DBGroup !== null) {
+            $this->DBGroup = $freeRadiusConfig->DBGroup;
+        }
+
+        parent::__construct($forge);
+
+        $this->tables = $freeRadiusConfig->tables;
+    }
+
+    public function up(): void
+    {
+        // Table structure for table 'radusergroup'
+        if ($this->db->tableExists($this->tables['radusergroup'])) {
+            $fields           = $this->db->getFieldData($this->tables['radusergroup']);
+            $primaryKeyExists = false;
+
+            foreach ($fields as $field) {
+                if ($field->primary_key) {
+                    $primaryKeyExists = true;
+                    break;
+                }
+            }
+
+            if (! $primaryKeyExists) {
+                $this->forge->addPrimaryKey('id');
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        if ($this->db->tableExists($this->tables['radusergroup'])) {
+            $this->forge->dropKey($this->tables['radusergroup'], 'PRIMARY');
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes changes to handle primary keys in the `radusergroup` table and updates to error handling in the `phpstan.neon.dist` file. The most important changes include removing the primary key addition from an existing migration, creating a new migration to handle primary key checks and updates, and adding a new error pattern to be ignored by PHPStan.

Changes to primary key handling:

* [`src/Database/Migrations/2024-01-21-223112_create_radius_tables.php`](diffhunk://#diff-3bf7393de87fceaae25f5652cbac4bf14df957cbdd66e44116e9739a1b11bc91L148): Removed the addition of the primary key from the `radusergroup` table.
* [`src/Database/Migrations/2024-12-02-223112_alter_radusegroup_primary_key.php`](diffhunk://#diff-6e7b02df494fceb2116823005431687383d9d7c7bf2ac59645d541a33d6dac37R1-R55): Added a new migration to check for the existence of the primary key and add it if it does not exist, as well as to remove the primary key during rollback.

Updates to error handling:

* [`phpstan.neon.dist`](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dR11): Added a new error pattern to ignore calls to an undefined method `CodeIgniter\Database\ConnectionInterface::getFieldData()`.