### PR TITLE
feat: add method to generate next free IP address

### DIFF
--- a/src/FreeRadius.php
+++ b/src/FreeRadius.php
@@ -117,7 +117,7 @@ class FreeRadius
 
         // Get all used IPs
         $usedIps = $radreplyModel->findAll();
-        $usedIps = array_map(static fn ($row) => ip2long($row['value']), $usedIps);
+        $usedIps = array_map(static fn ($row) => ip2long($row->value), $usedIps);
 
         // Generate all possible IPs within given range
         $allIps = range($ipStart, $ipEnd);
@@ -127,6 +127,32 @@ class FreeRadius
 
         // Generate random IP among free ones
         $randomIp = long2ip($freeIps[array_rand($freeIps)]);
+
+        return $randomIp;
+    }
+
+    public function generateNexFreeIpAddress(): string
+    {
+        helper('setting');
+
+        $radreplyModel = model(RadreplyModel::class);
+
+        // Define IP range
+        $ipStart = ip2long(setting('FreeRadius.ipStart'));
+        $ipEnd   = ip2long(setting('FreeRadius.ipEnd'));
+
+        // Get all used IPs
+        $usedIps = $radreplyModel->findAll();
+        $usedIps = array_map(static fn ($row) => ip2long($row->value), $usedIps);
+
+        // Generate all possible IPs within given range
+        $allIps = range($ipStart, $ipEnd);
+
+        // Subtract the used IPs, leave only free IPs
+        $freeIps = array_diff($allIps, $usedIps);
+
+        // Generate first free IP among free ones
+        $randomIp = long2ip(reset($freeIps));
 
         return $randomIp;
     }


### PR DESCRIPTION
This pull request includes changes to the `src/FreeRadius.php` file to enhance IP address generation functionality. The most important changes include fixing an issue with the retrieval of used IP addresses and adding a new method for generating the next free IP address.

Improvements to IP address generation:

* [`src/FreeRadius.php`](diffhunk://#diff-1fb1715e985bfa22da5bf293dd6c4575635502946c3a9441cc403e64280936e4L120-R120): Fixed the retrieval of used IP addresses by changing the array mapping to use object properties instead of array keys.

New functionality:

* [`src/FreeRadius.php`](diffhunk://#diff-1fb1715e985bfa22da5bf293dd6c4575635502946c3a9441cc403e64280936e4R134-R159): Added a new method `generateNexFreeIpAddress` to generate the next available IP address within a specified range. This method includes steps to define the IP range, retrieve used IPs, and identify the first free IP.