### PR TITLE
fix: remove 'notes' field from user info model and FreeRadius class

### DIFF
--- a/src/FreeRadius.php
+++ b/src/FreeRadius.php
@@ -90,7 +90,6 @@ class FreeRadius
             'address'           => $userInfo->address,
             'city'              => $userInfo->city,
             'netbox_address_id' => $userInfo->netbox_address_id,
-            'notes'             => $userInfo->notes,
             'created_by'        => null,
         ]) !== false;
     }

--- a/src/Models/UserinfoModel.php
+++ b/src/Models/UserinfoModel.php
@@ -21,7 +21,6 @@ class UserinfoModel extends BaseModel
         'address',
         'city',
         'netbox_address_id',
-        'notes',
         'created_by',
         'updated_by',
     ];


### PR DESCRIPTION
This pull request includes changes to the `FreeRadius` and `UserinfoModel` classes to remove the `notes` field from user information handling.

Changes to `FreeRadius` class:

* Removed the `notes` field from the `addUserInfo` method in `src/FreeRadius.php`.

Changes to `UserinfoModel` class:

* Removed the `notes` field from the list of attributes in `src/Models/UserinfoModel.php`.