### PR TITLE
refactor: remove DBGroup setting from radius table migrations and base model

### DIFF
--- a/src/Database/Migrations/2024-01-21-223112_create_radius_tables.php
+++ b/src/Database/Migrations/2024-01-21-223112_create_radius_tables.php
@@ -15,7 +15,6 @@ class CreateRadiusTables extends Migration
 
     public function __construct(?Forge $forge = null)
     {
-        $this->DBGroup = setting('FreeRadius.DBGroup');
         $this->tables  = setting('FreeRadius.tables');
         $this->db      = db_connect(setting('FreeRadius.database'));
 

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -14,7 +14,6 @@ class BaseModel extends Model
     public function __construct()
     {
         $this->tables  = setting('FreeRadius.tables');
-        $this->DBGroup = setting('FreeRadius.DBGroup');
         $this->db      = db_connect(setting('FreeRadius.database'));
         parent::__construct();
     }


### PR DESCRIPTION
This pull request includes changes to the database migration and model classes to remove the `DBGroup` setting. The most important changes are:

Database migration updates:

* [`src/Database/Migrations/2024-01-21-223112_create_radius_tables.php`](diffhunk://#diff-3bf7393de87fceaae25f5652cbac4bf14df957cbdd66e44116e9739a1b11bc91L18): Removed the `DBGroup` setting from the constructor of the `CreateRadiusTables` class.

Model class updates:

* [`src/Models/BaseModel.php`](diffhunk://#diff-19dfe8014fc6cf7542ad346ba88dc852a209f343657359347e17149bd8a40006L17): Removed the `DBGroup` setting from the constructor of the `BaseModel` class.