### PR TITLE
feat: Add Nas model and entity

### DIFF
--- a/src/Entities/Nas.php
+++ b/src/Entities/Nas.php
@@ -7,15 +7,15 @@ use CodeIgniter\Entity\Entity;
 /**
  * Class Nas
  *
+ * @property string $community
+ * @property string $description
  * @property int    $id
  * @property string $nasname
- * @property string $shortname
- * @property string $type
  * @property int    $ports
  * @property string $secret
  * @property string $server
- * @property string $community
- * @property string $description
+ * @property string $shortname
+ * @property string $type
  */
 class Nas extends Entity
 {

--- a/src/Entities/Nas.php
+++ b/src/Entities/Nas.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace IctSolutions\CodeIgniterFreeRadius\Entities;
+
+use CodeIgniter\Entity\Entity;
+
+/**
+ * Class Nas
+ *
+ * @property int    $id
+ * @property string $nasname
+ * @property string $shortname
+ * @property string $type
+ * @property int    $ports
+ * @property string $secret
+ * @property string $server
+ * @property string $community
+ * @property string $description
+ */
+class Nas extends Entity
+{
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'id'          => 'int',
+        'nasname'     => 'string',
+        'shortname'   => 'string',
+        'type'        => 'string',
+        'ports'       => 'int',
+        'secret'      => 'string',
+        'server'      => 'string',
+        'community'   => 'string',
+        'description' => 'string',
+    ];
+}

--- a/src/Models/NasModel.php
+++ b/src/Models/NasModel.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IctSolutions\CodeIgniterFreeRadius\Models;
+
+use IctSolutions\CodeIgniterFreeRadius\Entities\Nas;
+
+class NasModel extends BaseModel
+{
+    protected $primaryKey    = 'id';
+    protected $returnType    = Nas::class;
+    protected $allowedFields = [
+        'nasname',
+        'shortname',
+        'type',
+        'ports',
+        'secret',
+        'server',
+        'community',
+        'description',
+    ];
+    protected $useTimestamps      = false;
+    protected $validationRules    = [];
+    protected $validationMessages = [];
+    protected $skipValidation     = false;
+
+    protected function initialize(): void
+    {
+        parent::initialize();
+
+        $this->table = $this->tables['nas'];
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `Nas` entity and a corresponding `NasModel` to the CodeIgniter FreeRadius package. These changes are aimed at managing NAS (Network Access Server) data within the application.

### New Entity and Model:

* [`src/Entities/Nas.php`](diffhunk://#diff-448d295211c779601e3fb29a722b8d976e2cc03a700d9a61d6f624306ac30ff7R1-R36): Added a new `Nas` entity class with properties such as `id`, `nasname`, `shortname`, `type`, `ports`, `secret`, `server`, `community`, and `description`. This class extends `CodeIgniter\Entity\Entity` and includes type casting for each property.

* [`src/Models/NasModel.php`](diffhunk://#diff-b38c9e7e932a7d15363eab88560a490772b914959f1a26e2da494191734184fcR1-R34): Introduced a new `NasModel` class that extends `BaseModel`. This model is configured to use the `Nas` entity and manages fields such as `nasname`, `shortname`, `type`, `ports`, `secret`, `server`, `community`, and `description`. It also includes initialization to set the table name from the configuration.